### PR TITLE
[SML] Fix JSON parsing and serialization of typeOf and attachedTo links

### DIFF
--- a/sensorml-core/src/main/java/org/vast/sensorML/SMLJsonBindings.java
+++ b/sensorml-core/src/main/java/org/vast/sensorML/SMLJsonBindings.java
@@ -1998,6 +1998,12 @@ public class SMLJsonBindings
         if (bean.getRole() != null && rolePropName != null)
             writer.name(rolePropName).value(bean.getRole());
         
+        if (bean instanceof Reference) {
+            var ref = ((Reference)bean);
+            if (ref.isSetRemoteSchema())
+                mediaType = ref.getRemoteSchema();
+        }
+
         if (mediaType != null)
             writer.name("type").value(mediaType);
         

--- a/sensorml-core/src/main/java/org/vast/sensorML/SMLJsonBindings.java
+++ b/sensorml-core/src/main/java/org/vast/sensorML/SMLJsonBindings.java
@@ -804,11 +804,8 @@ public class SMLJsonBindings
         
         else if ("typeOf".equals(name))
         {
-            var link = readLink(reader);
             var ref = gmlFactory.newReference();
-            ref.setHref(link.getHref());
-            ref.setTitle(link.getTitle());
-            ref.setName(link.getName()); // UID
+            readLink(reader, ref);
             bean.setTypeOf(ref);
         }
         
@@ -1142,10 +1139,8 @@ public class SMLJsonBindings
     {
         if ("attachedTo".equals(name))
         {
-            var link = readLink(reader);
             var ref = gmlFactory.newReference();
-            ref.setHref(link.getHref());
-            ref.setTitle(link.getTitle());
+            readLink(reader, ref);
             bean.setAttachedTo(ref);
         }
         


### PR DESCRIPTION
When working with the consys API, I noticed that the uid property on a typeOf link would be dropped while parsing, preventing the "Implementing systems" link in the web UI from working (since that filters systems based on the uid of their typeOf attributes).

Looking at the code, I noticed that the uid property was parsed into an intermediate object, but then not copied into the final Reference object. Looking more closely at the code, I also noticed that the type attribute was also droped in this way, and looking for similar code, I noticed that for attachedTo also the name attribute was dropped.

I'm not sure if all of these attributes are actually relevant (the SensorML XML spec seems to only document "title" and "href" for these), but they are used in various examples and specs for Connected Systems, so I guess so.

I've fixed this parsing by avoiding the intermediate object and attribute copying, instead parsing directly into the resulting Reference object (which also seems supported by `readLinkProperties()`, which specially handles the "type" attribute when passed a Reference object (and not just a generic OgcPropertyObject), putting it into the "remoteSchema" attribute.

This fixed the parsing of "uid" and "type", but I noticed that in sml+json serializations, the "type" attribute was always "application/sml+json" again, regardless of what was stored. The second commit fixes this, by mirroring the Reference special case from `readLinkProperties()` in `writeLink()` as well.

Note that the sml+xml serialization now also shows a "remoteSchema" attribute (which seems ok, except that the [SensorML spec](https://docs.ogc.org/is/12-000r2/12-000r2.html) does not seem to specify this attribute anywhere. Also, the uid is stored as a "role", which makes it show up in the "role" attribute in the XML serialization as well (while the [SensorML spec says it should be in the xlink:title attribute](https://docs.ogc.org/is/12-000r2/12-000r2.html#83).


In any case, I do not fully understand the ecosystem yet, so I am not sure if this PR applies the right fix, so please help me understand if not.